### PR TITLE
made public tags and tag reads appear when no user is logged in

### DIFF
--- a/etag/views.py
+++ b/etag/views.py
@@ -106,9 +106,11 @@ class TagsViewSet(viewsets.ModelViewSet):
 	
     def get_queryset(self):
         user = self.request.user
-        if not user:
-            return []
-        return Tags.objects.filter(user_id=user.id)
+        if self.request.user.is_authenticated():
+                if not user:
+                        return []
+                return Tags.objects.filter(user_id=user.id)
+        return Tags.objects.filter(public=True)
 		
     def create(self, request):
         serializer = self.serializer_class(data=request.DATA)
@@ -131,17 +133,19 @@ class TagReadsViewSet(viewsets.ModelViewSet):
     filter_backends = (filters.DjangoFilterBackend, filters.SearchFilter, filters.OrderingFilter)
     filter_class = TagReadsFilter
     search_fields = ('tag_id',)
-    ordering_fields =  '__all__' 
-	
+    ordering_fields =  '__all__' 	
     def get_queryset(self):
-		public_data=self.request.DATA.get('public', None)
-		user = self.request.user
-		if public_data:
-			return TagReads.objects.filter(tag__public = True)
-        	elif not user:
-            		return []
-		else :             
-        		return TagReads.objects.filter(tag__user_id = user.id)
+        if self.request.user.is_authenticated():
+                public_data=self.request.DATA.get('public', None)
+                user = self.request.user
+                if public_data:
+                        return TagReads.objects.filter(tag__public = True)
+                elif not user:
+                        return []
+                else :
+                        return TagReads.objects.filter(tag__user_id = user.id)
+        public_tags = Tags.objects.filter(public=True).values_list('tag_id')
+        return TagReads.objects.filter(tag_id__in=public_tags)
 	
 class AccessoryDataViewSet(viewsets.ModelViewSet):
     """


### PR DESCRIPTION
Tags and tag reads who have public value set to "true" are made to appear when no user is logged in. If any user is logged in, he can see all his tag entries regardless the public value is set to true or false.